### PR TITLE
Filter receivers/volunteers being notified based on operation hours

### DIFF
--- a/server/src/entity/operation-hours.entity.ts
+++ b/server/src/entity/operation-hours.entity.ts
@@ -1,18 +1,20 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, Index } from 'typeorm';
 import { AccountEntity } from './account.entity';
 import { OperationHours } from '../../../shared/src/interfaces/account/account';
 import { Constants } from '../../../shared/src/constants/constants';
+import { Weekday } from '../../../shared/src/interfaces/account/operation-hours';
 
 const _constants = new Constants();
 
 @Entity('OperationHours')
+@Index(['weekday', 'startTime', 'endTime'])
 export class OperationHoursEntity implements OperationHours {
 
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column({ type: 'enum', enum: _constants.WEEKDAYS })
-  weekday: string;
+  weekday: Weekday;
 
   @Column('time')
   startTime: string;

--- a/server/src/helpers/query-builder-helper.ts
+++ b/server/src/helpers/query-builder-helper.ts
@@ -1,0 +1,81 @@
+import { SelectQueryBuilder } from 'typeorm';
+import { PagingParams } from '../../../shared/src/interfaces/paging-params';
+
+/**
+ * Generates simple where clause conditions of the SQL query. Simple conditions have a 1-1 mapping between the given filter parameter names
+ * and the given SQL table's properties. If the filter properties are undefined, then they are ignored.
+ * @param queryBuilder The query builder to add where clause conditions to.
+ * @param tableAlias The alias for the table to filter in the SQL query.
+ * @param filters The filters to apply. Can be a superset of the simple SQL filters.
+ * @param filterProps A list of the property names within the given filters object that should be used to generate simple where conditions.
+ * @param splitFilterOnComma Optional flag that defaults to true. When set, any filter values that are strings that contain comma separated
+ * lists will be used to generate an 'IN()' SQL condition instead of one of strict equality.
+ * @return The input queryBuilder with simple where clause conditions added.
+ */
+export function genSimpleWhereConditions<T, F>(
+  queryBuilder: SelectQueryBuilder<T>,
+  tableAlias: string,
+  filters: F,
+  filterProps: string[],
+  splitFilterOnComma = true
+): SelectQueryBuilder<T> {
+  filterProps.forEach((filterProp: string) => {
+    if (filters[filterProp] != null) {
+      queryBuilder = (splitFilterOnComma && typeof filters[filterProp] === 'string' && filters[filterProp].indexOf(',') >= 0)
+        ? _genSimpleInListCondition(queryBuilder, tableAlias, filters, filterProp)
+        : _genSimpleEqualCondition(queryBuilder, tableAlias, filters, filterProp)
+    } else if (filters[filterProp] !== undefined) {
+      queryBuilder = _genSimpleNullCondition(queryBuilder, tableAlias, filterProp);
+    }
+  });
+  return queryBuilder;
+}
+
+function _genSimpleInListCondition<T, F>(
+  queryBuilder: SelectQueryBuilder<T>,
+  tableAlias: string,
+  filters: F,
+  filterProp: string
+): SelectQueryBuilder<T> {
+  const filterPropObj = {};
+  filterPropObj[filterProp] = filters[filterProp].split(',');
+  return queryBuilder.andWhere(`${tableAlias}.${filterProp} IN (:...${filterProp})`, filterPropObj);
+}
+
+function _genSimpleEqualCondition<T, F>(
+  queryBuilder: SelectQueryBuilder<T>,
+  tableAlias: string,
+  filters: F,
+  filterProp: string
+): SelectQueryBuilder<T> {
+  const filterPropObj = {};
+  filterPropObj[filterProp] = filters[filterProp];
+  return queryBuilder.andWhere(`${tableAlias}.${filterProp} = :${filterProp}`, filterPropObj);
+}
+
+function _genSimpleNullCondition<T>(
+  queryBuilder: SelectQueryBuilder<T>,
+  tableAlias: string,
+  filterProp: string
+): SelectQueryBuilder<T> {
+  return queryBuilder.andWhere(`${tableAlias}.${filterProp} IS NULL`);
+}
+
+/**
+ * Generates the pagination portion of the SQL query.
+ * @param queryBuilder The query builder to add pagination SQL to.
+ * @param pagingParams The paging parameters submitted in the GET request.
+ * @param defaultLimit An optional default limit if pagingParams.limit is undefined. Defaults to 10.
+ * @return The input queryBuilder with pagination SQL added.
+ */
+export function genPagination<T>(
+  queryBuilder: SelectQueryBuilder<T>,
+  pagingParams: PagingParams,
+  defaultLimit = 10
+): SelectQueryBuilder<T> {
+  if (!pagingParams.page) { pagingParams.page = 1 };
+  if (!pagingParams.limit) { pagingParams.limit = defaultLimit };
+  return queryBuilder
+    .skip((pagingParams.page - 1) * pagingParams.limit)
+    .take(pagingParams.limit);
+}

--- a/server/src/migration/1563129237967-operation-hours-idx.ts
+++ b/server/src/migration/1563129237967-operation-hours-idx.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class operationHoursIdx1563129237967 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_4a67194a67f9217a63275eaeb2" ON "OperationHours" ("weekday", "startTime", "endTime") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`DROP INDEX "IDX_4a67194a67f9217a63275eaeb2"`);
+  }
+}

--- a/server/src/services/read-accounts.ts
+++ b/server/src/services/read-accounts.ts
@@ -1,8 +1,9 @@
-import { getRepository, FindConditions } from 'typeorm';
+import { getRepository, SelectQueryBuilder } from 'typeorm';
 import { AccountEntity } from '../entity/account.entity';
+import { genSimpleWhereConditions, genPagination } from '../helpers/query-builder-helper';
 import { OperationHoursHelper } from '../../../shared/src/helpers/operation-hours-helper';
-import { Account } from '../../../shared/src/interfaces/account/account';
-import { AccountReadRequest } from '../../../shared/src/interfaces/account/account-read-request';
+import { Account, OperationHours } from '../../../shared/src/interfaces/account/account';
+import { AccountReadRequest, AccountReadFilters } from '../../../shared/src/interfaces/account/account-read-request';
 import { AccountHelper } from '../../../shared/src/helpers/account-helper';
 
 export interface AccountsQueryResult {
@@ -23,22 +24,71 @@ export async function readAccount(idOrUsername: number | string, myAccount?: Acc
 }
 
 export async function readAccounts(request: AccountReadRequest, myAccount?: Account): Promise<AccountsQueryResult> {
-  const [accounts, totalCount]: [AccountEntity[], number] = await getRepository(AccountEntity).findAndCount({
-    where: _genFindConditions(request),
-    skip: (request.page - 1) * request.limit,
-    take: request.limit,
-    order: { username: 'ASC' }
-  });
-
+  const queryBuilder: SelectQueryBuilder<AccountEntity> = _buildQuery(request, myAccount);
+  const [accounts, totalCount]: [AccountEntity[], number] = await queryBuilder.getManyAndCount();
   _postProcessAccounts(accounts, myAccount);
   return { accounts, totalCount };
 }
 
-function _genFindConditions(request: AccountReadRequest): FindConditions<AccountEntity> {
-  const conditions: FindConditions<AccountEntity> = Object.assign({}, request);
-  delete conditions['page'];
-  delete conditions['limit'];
-  return conditions;
+function _buildQuery(request: AccountReadRequest, myAccount: Account): SelectQueryBuilder<AccountEntity> {
+  let queryBuilder: SelectQueryBuilder<AccountEntity> = getRepository(AccountEntity).createQueryBuilder('account');
+  queryBuilder = _genJoins(queryBuilder);
+  queryBuilder = _genWhereCondition(queryBuilder, request, myAccount);
+  queryBuilder = _genOrdering(queryBuilder);
+  queryBuilder = genPagination(queryBuilder, request);
+  return queryBuilder;
+}
+
+function _genJoins(queryBuilder: SelectQueryBuilder<AccountEntity>): SelectQueryBuilder<AccountEntity> {
+  return queryBuilder
+    .innerJoinAndSelect('account.contactInfo', 'contactInfo')
+    .leftJoinAndSelect('account.organization', 'organization')
+    .leftJoinAndSelect('account.volunteer', 'volunteer')
+    .leftJoinAndMapMany('account.operationHours', 'account.operationHours', 'operationHours');
+}
+
+function _genWhereCondition(
+  queryBuilder: SelectQueryBuilder<AccountEntity>,
+  filters: AccountReadFilters,
+  myAccount: Account
+): SelectQueryBuilder<AccountEntity> {
+  queryBuilder = genSimpleWhereConditions(queryBuilder, 'account', filters, ['id', 'username', 'accountType']);
+  queryBuilder = genSimpleWhereConditions(queryBuilder, 'contactInfo', filters, ['email']);
+  queryBuilder = genSimpleWhereConditions(queryBuilder, 'organization', filters, ['organizationName']);
+  queryBuilder = _genOperationHoursCondition(queryBuilder, filters, myAccount);
+  return queryBuilder;
+}
+
+function _genOperationHoursCondition(
+  queryBuilder: SelectQueryBuilder<AccountEntity>,
+  filters: AccountReadFilters,
+  myAccount: Account
+): SelectQueryBuilder<AccountEntity> {
+  if (filters.operationHoursRange) {
+    const operationHours: OperationHours = _opHoursHelper.dateTimeRangeToOperationHours(
+      filters.operationHoursRange,
+      myAccount.contactInfo.timezone
+    );
+    // Check for any overlap (invert condition where op hours are completely after or before donation window).
+    queryBuilder = queryBuilder.andWhere(
+      'operationHours.weekday = :weekday ' +
+      'AND NOT (' +
+        'operationHours.startTime >= :endTime ' +
+        'OR operationHours.endTime <= :startTime' +
+      ')',
+      operationHours
+    );
+  }
+  return queryBuilder;
+}
+
+function _genOrdering(
+  queryBuilder: SelectQueryBuilder<AccountEntity>
+): SelectQueryBuilder<AccountEntity> {
+  return queryBuilder
+    .addOrderBy('organization.organizationName', 'ASC')
+    .addOrderBy('volunteer.lastName', 'ASC')
+    .addOrderBy('volunteer.firstName', 'ASC')
 }
 
 function _postProcessAccounts(accounts: AccountEntity[], myAccount: Account): void {

--- a/shared/src/constants/constants.ts
+++ b/shared/src/constants/constants.ts
@@ -1,9 +1,10 @@
 import { AccountType } from './../interfaces/account/account';
 import { DonationStatus } from '../interfaces/donation/donation';
 import { AuditEventType } from '../interfaces/audit/audit';
+import { Weekday } from '../interfaces/account/operation-hours';
 
 export class Constants {
-  readonly WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  readonly WEEKDAYS: Weekday[] = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
   readonly ACCOUNT_TYPES: AccountType[] = ['Donor', 'Receiver', 'Volunteer'];
   readonly DONATION_TYPES = ['Food', 'Merchandise', 'Cash', 'Service', 'Other'];
   readonly DONATION_STATUSES: DonationStatus[] = ['Unmatched', 'Matched', 'Scheduled', 'Picked Up', 'Complete'];

--- a/shared/src/helpers/operation-hours-helper.ts
+++ b/shared/src/helpers/operation-hours-helper.ts
@@ -1,10 +1,13 @@
-import { OperationHours } from '..//interfaces/account/operation-hours';
+import { DateTimeHelper } from './date-time-helper'
 import { Constants } from '../constants/constants';
+import { DateTimeRange } from '../interfaces/misc/time';
+import { OperationHours } from '../interfaces/account/operation-hours';
 export { OperationHours };
 
 export class OperationHoursHelper {
 
-  readonly _constants = new Constants();
+  private readonly _dateTimeHelper = new DateTimeHelper()
+  private readonly _constants = new Constants();
 
   /**
    * Sorts a given operation hours array.
@@ -54,5 +57,23 @@ export class OperationHoursHelper {
     const minuteStr: string = (minutes > 9 ? `${minutes}` : `0${minutes}`);
 
     return `${hourStr}:${minuteStr} ${amPmStr}`;
+  }
+
+  /**
+   * Converts a date-time range to operation hours.
+   * @param dateTimeRange The date-time range.
+   * @param timezone The optional timezone of the operation hours output. Defaults to 'UTC'.
+   * @return The operation hours.
+   */
+  dateTimeRangeToOperationHours(dateTimeRange: DateTimeRange, timezone = 'UTC'): OperationHours {
+    const startWeekdayIdx: number = dateTimeRange.startDateTime.getDay();
+    // const endWeekdayIdx: number = dateTimeRange.endDateTime.getDay();
+    // TODO: If dateTimeRange spans multiple days, then generate operation hours for each of those days.
+    const operationHours: OperationHours = {
+      weekday: this._constants.WEEKDAYS[startWeekdayIdx],
+      startTime: this._dateTimeHelper.toLocalTimeStr(dateTimeRange.startDateTime, timezone),
+      endTime: this._dateTimeHelper.toLocalTimeStr(dateTimeRange.endDateTime, timezone)
+    }
+    return operationHours;
   }
 }

--- a/shared/src/interfaces/account/account-read-filters.ts
+++ b/shared/src/interfaces/account/account-read-filters.ts
@@ -1,4 +1,5 @@
 import { AccountType } from './account';
+import { DateTimeRange } from '../misc/time';
 
 export interface AccountReadFilters {
   id?: number;
@@ -6,4 +7,5 @@ export interface AccountReadFilters {
   accountType?: AccountType;
   email?: string;
   organizationName?: string;
+  operationHoursRange?: DateTimeRange;
 }

--- a/shared/src/interfaces/account/operation-hours.ts
+++ b/shared/src/interfaces/account/operation-hours.ts
@@ -1,6 +1,8 @@
+export type Weekday = 'Sunday' | 'Monday' | 'Tuesday' | 'Wednesday' | 'Thursday' | 'Friday' | 'Saturday'
+
 export interface OperationHours {
   id?: number;
-  weekday: string;
+  weekday: Weekday;
   startTime: string;
   endTime: string;
 }


### PR DESCRIPTION
Create query builder helpers for applying simple GET filters and pagination.
Improve type-safety of weekday properties.
Add logic for only messaging receivers/volunteers about any donation if they have overlapping operation hours with the delivery window.