### PR TITLE
Remove window injection so that account read service will work with nativescript

### DIFF
--- a/client/projects/web/src/app/account/services/account-read/account-read.service.ts
+++ b/client/projects/web/src/app/account/services/account-read/account-read.service.ts
@@ -20,7 +20,6 @@ export class AccountReadService {
     private _httpClient: HttpClient,
     private _router: Router,
     private _sessionService: SessionService,
-    private _window: Window,
   ) {}
 
   updateURLQueryString(filters: AccountReadRequest, activatedRoute: ActivatedRoute): void {
@@ -56,11 +55,6 @@ export class AccountReadService {
     // Attempt to get account from session storage.
     if (id == null) {
       return of(this._sessionService.account);
-    }
-
-    // Attempt to get account from window state history.
-    if (this._window.history.state?.account?.id === id) {
-      return of(this._window.history.state.account);
     }
 
     // Get account from server.


### PR DESCRIPTION
Title pretty much says it all.

Note that this will remove the ability to pass data from the account list page to the detail page, and will lead the service to always make a query to the server. The plan is to reduce the amount of data queried for the account list page eventually anyways. So, when an account is selected from the list page, it will not have the full data needed for the account details anyways. I will create a card in the backlog for this.

https://trello.com/c/Yj5xsBG0/7-modify-accountreadservice-so-that-it-can-be-used-by-both-web-app