### PR TITLE
Set contact info notification flags to true by default to fix signup error

### DIFF
--- a/client/projects/web/src/app/account-shared/forms/contact-info.form.ts
+++ b/client/projects/web/src/app/account-shared/forms/contact-info.form.ts
@@ -15,9 +15,9 @@ export class ContactInfoForm extends TFormGroup<ContactInfo> {
       postalCode: ['', [Validators.required, Validators.pattern(Validation.POSTAL_CODE_REGEX)]],
       location: undefined,
       timezone: undefined,
-      enableEmail: undefined,
-      enablePushNotification: undefined,
-      notifyForEachDonation: undefined
+      enableEmail: true,
+      enablePushNotification: true,
+      notifyForEachDonation: true
     });
     if (contactInfo) {
       this.patchValue(contactInfo);


### PR DESCRIPTION
The title says it all.

There was a recent change where these fields were added to the ContactInfoForm with undefined values as their default. This caused an attempt to save null values to these fields on signup, which produced an error.

https://trello.com/c/4oCGvDrL/13-fix-issue-with