### PR TITLE
Improve Nativescript Debug Errors

### DIFF
--- a/client/projects/app/src/app/app-shared/services/app-error-handler/app-error-handler.service.ts
+++ b/client/projects/app/src/app/app-shared/services/app-error-handler/app-error-handler.service.ts
@@ -1,0 +1,15 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+
+/**
+ * A global error handler that handles all errors produced by application-wide uncaught exceptions.
+ * By default, `console.error(error)` is invoked for each uncaught error, but this does not print out the full stack trace in Nativescript.
+ * Instead, we explicitly print the error's stack in order to get a detailed error message.
+ *
+ * Note: This is provided in AppModule.
+ */
+@Injectable()
+export class AppErrorHandlerService implements ErrorHandler {
+  handleError(error: Error): void {
+    console.error(error.stack);
+  }
+}

--- a/client/projects/app/src/app/app.module.ts
+++ b/client/projects/app/src/app/app.module.ts
@@ -1,11 +1,12 @@
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ErrorHandler, NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
 import { NativeScriptFormsModule, NativeScriptHttpClientModule, NativeScriptModule } from '@nativescript/angular';
 import { NativeScriptUISideDrawerModule } from 'nativescript-ui-sidedrawer/angular';
 import { AppRoutingModule } from '~app/app-routing.module';
 import { AppSessionModule } from '~app/app-session/app-session.module';
 import { AppSessionMonitorService } from '~app/app-session/services/app-session-monitor/app-session-monitor.service';
 import { AppSharedModule } from '~app/app-shared/app-shared.module';
+import { AppErrorHandlerService } from '~app/app-shared/services/app-error-handler/app-error-handler.service';
 import { AppShellModule } from '~app/app-shell/app-shell.module';
 import { AppComponent } from '~app/app.component';
 import { AppHomeComponent } from '~app/components/app-home/app-home.component';
@@ -33,6 +34,7 @@ import { AppSessionService } from './app-session/services/app-session/app-sessio
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: AppSessionMonitorService, multi: true },
     { provide: AuthenticationService, useClass: AppAuthenticationService },
+    { provide: ErrorHandler, useClass: AppErrorHandlerService },
     { provide: SessionService, useClass: AppSessionService },
     AccountHelper,
     DeliveryHelper,

--- a/client/projects/web/src/app/shared/services/page-progress/page-progress.service.ts
+++ b/client/projects/web/src/app/shared/services/page-progress/page-progress.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Event, Router } from '@angular/router';
+import { Event, NavigationEnd, Router } from '@angular/router';
 
 @Injectable({
   providedIn: 'root'
@@ -69,7 +69,7 @@ export class PageProgressService {
 
   protected _listenForRouteChange(router: Router): void {
     router.events.subscribe((event: Event) => {
-      if (event instanceof PageTransitionEvent) {
+      if (event instanceof NavigationEnd) {
         this.trigger = false;
       }
     });


### PR DESCRIPTION
Add an `AppErrorHandlerService` that intercepts all errors associated with uncaught exceptions within the Nativescript app.
Explicitly print the stack trace of each error so that context is given for each output error message.