### PR TITLE
Fix various input field style spacing errors.

### DIFF
--- a/client/projects/app/src/styles/fields.scss
+++ b/client/projects/app/src/styles/fields.scss
@@ -1,0 +1,12 @@
+@import "constants.scss";
+
+/* Fixes a styling error introduced by latest nativescript theme.
+ * See: https://github.com/NativeScript/theme/issues/264 */
+TextView.ng-valid,
+TextField.ng-valid,
+PickerField.ng-valid,
+DatePickerField.ng-valid,
+TimePickerField.ng-valid,
+RadAutoCompleteTextView.ng-valid{
+  margin-bottom: 0;
+}

--- a/client/projects/app/src/styles/styles.scss
+++ b/client/projects/app/src/styles/styles.scss
@@ -6,6 +6,7 @@
 @import "button.scss";
 @import "dialog.scss";
 @import "drawer.scss";
+@import "fields.scss";
 @import "icon.scss";
 @import "label.scss";
 @import "page.scss";


### PR DESCRIPTION
This is a simple styling bug fix for the latest version of NativeScript.

All TextFields and related form fields have unnecessary spacing added to them once they become valid when using reactive form controls. This neutralizes the unwanted spacing.

This will likely be fixed in patch that will be released in the near future, so we can get rid of the fix then. I've included the primary GitHub issue within the code comments for reference.

https://trello.com/c/3noDlRcT/16-remove-unnecessary-spacing-when-typing-in-various-nativescript-input-fields